### PR TITLE
Dev line classification

### DIFF
--- a/elsed_ssl.py
+++ b/elsed_ssl.py
@@ -139,21 +139,24 @@ if __name__ == "__main__":
         
         import time
         t0 = time.time()
-        segments, scores = pyelsed.detect(original_img, 1, 30, 150)
+        segments, scores, labels = pyelsed.detect(original_img, 1, 30, 150)
         print(f'elapsed_time: {time.time() - t0}')
         gs_img = cv2.cvtColor(gs_img, cv2.COLOR_GRAY2BGR)
         
-        for s in segments.astype(np.int32):
+        for s, label in zip(segments.astype(np.int32), labels):
             line_points = get_bresenham_line_points(s)
             
-            gx, gy = get_gradients_from_line_points(original_img, line_points)
+            #gx, gy = get_gradients_from_line_points(original_img, line_points)
             
-            if np.linalg.norm(gy)>np.linalg.norm(gx): g = gy
-            else: g = gx
+            #if np.linalg.norm(gy)>np.linalg.norm(gx): g = gy
+            #else: g = gx
 
-            is_field_boundary = check_boundary_classification(g, len(line_points))
-            is_field_marking = check_marking_classification(g, len(line_points))
+            #is_field_boundary = check_boundary_classification(g, len(line_points))
+            #is_field_marking = check_marking_classification(g, len(line_points))
             
+            is_field_boundary = (label==1)
+            is_field_marking = (label==2)
+
             for p in line_points:
                 x, y = p
                 gs_img[y, x] = RED

--- a/elsed_ssl.py
+++ b/elsed_ssl.py
@@ -4,6 +4,8 @@ import cv2
 from scipy.signal import convolve2d
 import random
 import os
+import time
+
 
 WHITE = np.array([255, 255, 255])
 BLUE =  np.array([255, 0, 0])
@@ -137,7 +139,6 @@ if __name__ == "__main__":
         #dbg_img = cv2.cvtColor(gs_img, cv2.COLOR_GRAY2RGB)
         dbg_img = original_img.copy()
         
-        import time
         t0 = time.time()
         segments, scores, labels = pyelsed.detect(original_img, 1, 30, 150)
         print(f'elapsed_time: {time.time() - t0}')

--- a/elsed_ssl.py
+++ b/elsed_ssl.py
@@ -131,6 +131,7 @@ if __name__ == "__main__":
     max_img_nr = 2000
     while True:
         original_img, img_path, img_details = get_random_img_from_dataset(dataset_path, scenarios, rounds, max_img_nr)
+        #original_img, img_path = get_img_from_dataset(dataset_path, 'rnd', 2, 1566)
         print(f"Img: {img_path}")
         gs_img = cv2.cvtColor(original_img, cv2.COLOR_BGR2GRAY)
         #dbg_img = cv2.cvtColor(gs_img, cv2.COLOR_GRAY2RGB)
@@ -138,7 +139,7 @@ if __name__ == "__main__":
         
         import time
         t0 = time.time()
-        segments, scores = pyelsed.detect(original_img, 1, 30, 100)
+        segments, scores = pyelsed.detect(original_img, 1, 30, 150)
         print(f'elapsed_time: {time.time() - t0}')
         gs_img = cv2.cvtColor(gs_img, cv2.COLOR_GRAY2BGR)
         

--- a/src/ELSED.cpp
+++ b/src/ELSED.cpp
@@ -215,17 +215,24 @@ bool checkBoundaryClassification(const std::array<float, 3> &g_BGRy,
   float angle_threshold = angle_threshold_deg * 3.1415 / 180;
 
   // Compute the dot product of g_BGRy and GREEN
-  float projection = g_BGRy[0] * GREEN[0] + g_BGRy[1] * GREEN[1] + g_BGRy[2] * GREEN[2];
+  float projection = -(g_BGRy[0] * GREEN[0] + 
+                       g_BGRy[1] * GREEN[1] + 
+                       g_BGRy[2] * GREEN[2]);
 
   // Compute the norms of g_BGRy and GREEN
-  float norm_g = std::sqrt(g_BGRy[0] * g_BGRy[0] + g_BGRy[1] * g_BGRy[1] + g_BGRy[2] * g_BGRy[2]);
-  float norm_GREEN = std::sqrt(GREEN[0] * GREEN[0] + GREEN[1] * GREEN[1] + GREEN[2] * GREEN[2]);
+  float norm_g = std::sqrt(g_BGRy[0] * g_BGRy[0] + 
+                           g_BGRy[1] * g_BGRy[1] + 
+                           g_BGRy[2] * g_BGRy[2]);
+  float norm_GREEN = std::sqrt(GREEN[0] * GREEN[0] + 
+                               GREEN[1] * GREEN[1] + 
+                               GREEN[2] * GREEN[2]);
 
   // Compute the angle between g_BGRy and GREEN
   float proj_angle = std::acos(projection / (norm_g * norm_GREEN));
 
   // Check if the pixel is a field boundary
-  bool is_field_boundary = (projection > gradient_threshold && std::abs(proj_angle) < angle_threshold);
+  bool is_field_boundary = (projection > gradient_threshold && 
+                            std::abs(proj_angle) < angle_threshold);
 
   return is_field_boundary;
 }
@@ -280,19 +287,18 @@ bool isFieldFeature(const cv::Mat &B, const cv::Mat &G, const cv::Mat &R) {
     auto [g_BGRx, g_BGRy] = computeGradientsBGR(B, G, R);
 
     // Check boundary classification for g_BGRy
-    bool is_boundary = checkBoundaryClassification(g_BGRy);
+    if (checkBoundaryClassification(g_BGRy)) return true;
     // std::cout << "Boundary classification y-axis: " << std::boolalpha << is_boundary << std::endl;
 
     // Check marking classification for g_BGRy and g_BGRx
-    bool is_marking_y = checkMarkingClassification(g_BGRx);
+    if (checkMarkingClassification(g_BGRy)) return true;
     // std::cout << "Marking classification x-axis: " << std::boolalpha << is_marking_y << std::endl;
 
     // Check marking classification for g_BGRy and g_BGRx
-    bool is_marking_x = checkMarkingClassification(g_BGRy);
+    if (checkMarkingClassification(g_BGRx)) return true;
     // std::cout << "Marking classification y-axis: " << std::boolalpha << is_marking_x << std::endl;
 
-    bool result = is_boundary || is_marking_y || is_marking_x;
-    return result;
+    return false;
 }
 
 inline void ELSED::computeAnchorPoints(const cv::Mat &dirImage,
@@ -411,8 +417,8 @@ void ELSED::drawAnchorPoints(const uint8_t *dirImg,
       // If anchor i is already been an edge pixel
       continue;
     }
-    if (!extractWindowAndChannels(BGR_image, anchorPoint.x, anchorPoint.y, B, G, R)) continue;
-    if (!isFieldFeature(B, G, R)) continue;
+    //if (!extractWindowAndChannels(BGR_image, anchorPoint.x, anchorPoint.y, B, G, R)) continue;
+    //if (!isFieldFeature(B, G, R)) continue;
 
     // If the direction of this pixel is horizontal, then go left and right.
     expandHorizontally = dirImg[indexInArray] == UPM_EDGE_HORIZONTAL;
@@ -441,7 +447,10 @@ void ELSED::drawAnchorPoints(const uint8_t *dirImg,
   salientSegments.reserve(drawer->getDetectedFullSegments().size());
 
   for (const FullSegmentInfo &detectedSeg: drawer->getDetectedFullSegments()) {
-
+    cv::Mat B_sum = cv::Mat::zeros(3, 3, CV_32F);
+    cv::Mat G_sum = cv::Mat::zeros(3, 3, CV_32F);
+    cv::Mat R_sum = cv::Mat::zeros(3, 3, CV_32F);
+    int segment_size = 0;
     valid = true;
     if (params.validate) {
       if (detectedSeg.getNumOfPixels() < 2) {
@@ -515,9 +524,33 @@ void ELSED::drawAnchorPoints(const uint8_t *dirImg,
           if (angle < 0) angle += M_PI;
           if (angle >= M_PI) angle -= M_PI;
           circularDist(theta, angle, M_PI) > validationTh ? nOriOutliers++ : nOriInliers++;
+          
+          // Implement here a function to:
+          // 1. Get the window around each px
+          // 2. Sum the windows along the pixels and save the number of sums to make an average in the end
+          if (!extractWindowAndChannels(BGR_image, px.x, px.y, B, G, R)) continue;
+          //std::cout << "B_sum:" << std::endl << B_sum << std::endl;
+          //std::cout << "B:" << std::endl << B << std::endl;
+          B.convertTo(B, CV_32F);
+          cv::add(B_sum, B, B_sum);
+          G.convertTo(G, CV_32F);
+          cv::add(G_sum, G, G_sum);
+          R.convertTo(R, CV_32F);
+          cv::add(R_sum, R, R_sum);
+          segment_size++;
         }
-
-        valid = nOriInliers > nOriOutliers;
+        // Implement here:
+        // 1. B, G, R = average_window/N
+        // 2. valid = isFieldFeature(B, G, R) && nOriInliers > nOriOutliers
+        B = B_sum/segment_size;
+        G = G_sum/segment_size;
+        R = R_sum/segment_size;
+        //std::cout << "B:" << std::endl << B << std::endl;
+        //std::cout << "G:" << std::endl << B << std::endl;
+        //std::cout << "R:" << std::endl << B << std::endl;
+        //if (!isFieldFeature(B, G, R)) continue;
+        //printf("segment size: %d\n", segment_size);
+        valid = nOriInliers > nOriOutliers && isFieldFeature(B, G, R);
         saliency = nOriInliers;
       }
     } else {

--- a/src/ELSED.cpp
+++ b/src/ELSED.cpp
@@ -405,6 +405,11 @@ void ELSED::drawAnchorPoints(const uint8_t *dirImg,
     // LOGD << "Managing new Anchor point: " << anchorPoint;
     indexInArray = anchorPoint.y * imageWidth + anchorPoint.x;
 
+    // TODO: MOVE FIELD FEATURE CLASSIFICATION TO HERE
+    // 1. Get window from anchor position in the BGR image
+    // 2. If window is ont available: continue
+    // 3. If anchor is not field feature: continue
+
     if (pEdgeImg[indexInArray]) {
       // If anchor i is already been an edge pixel
       continue;

--- a/src/ELSED.h
+++ b/src/ELSED.h
@@ -100,6 +100,7 @@ class ELSED {
  private:
   void drawAnchorPoints(const uint8_t *dirImg,
                         const std::vector<Pixel> &anchorPoints,
+                        const cv::Mat &BGR_image,
                         uint8_t *pEdgeImg);  // NOLINT
 
   ELSEDParams params;

--- a/src/PYAPI.cpp
+++ b/src/PYAPI.cpp
@@ -9,18 +9,21 @@ using namespace upm;
 
 // Converts C++ descriptors to Numpy
 inline py::tuple salient_segments_to_py(const upm::SalientSegments &ssegs) {
-  py::array_t<float> scores(ssegs.size());
+  py::array_t<float> scores({int(ssegs.size()), 1});
+  py::array_t<float> labels({int(ssegs.size()), 1});
   py::array_t<float> segments({int(ssegs.size()), 4});
   float *p_scores = scores.mutable_data();
+  float *p_labels = labels.mutable_data();
   float *p_segments = segments.mutable_data();
   for (int i = 0; i < ssegs.size(); i++) {
     p_scores[i] = ssegs[i].salience;
+    p_labels[i] = ssegs[i].classification;
     p_segments[i * 4] = ssegs[i].segment[0];
     p_segments[i * 4 + 1] = ssegs[i].segment[1];
     p_segments[i * 4 + 2] = ssegs[i].segment[2];
     p_segments[i * 4 + 3] = ssegs[i].segment[3];
   }
-  return pybind11::make_tuple(segments, scores);
+  return pybind11::make_tuple(segments, scores, labels);
 }
 
 py::tuple compute_elsed(const py::array &py_img,

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -191,7 +191,6 @@ segAngle(const Segment &s) {
     return std::atan2(s[1] - s[3], s[0] - s[2]);
 }
 
-
 /**
  * Returns the line pixels using the Bresenham Algorithm:
  * https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm


### PR DESCRIPTION
Adds features to classify line segments during segments validation:
- Extracts 3x3 window from each pixel of the segment and adds them up, for each channel (B, G, R)
- After summing all windows, gets their means (divides by segment length)
- The average window is used to classify the segment using isFieldFeature(B, G, R) :
```
#define NOT_A_FIELD_LINE 0
#define FIELD_BOUNDARY 1
#define FIELD_MARKING 2
```
- `pyelsed.detect` method now returns: segments, scores, and labels